### PR TITLE
Fixup GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "mix dependencies"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019]
+        elixir: ['1.12.3', '1.13.4']
         include:
-          - elixir: '1.13.4'
-            otp: '24'
-          - elixir: '1.12.3'
-            otp: '24'
+          - otp: '24'
     env:
       MIX_ENV: test
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           elixir-version: '1.13.4'
           otp-version: '24'
-      - run: mix deps.get
+      - run: mix deps.get --only
       - run: mix format --check-formatted
       - run: mix deps.unlock --check-unused
 
@@ -44,7 +44,7 @@ jobs:
         with:
           elixir-version: ${{matrix.elixir}}
           otp-version: ${{matrix.otp}}
-      - run: mix deps.get --only test
+      - run: mix deps.get --only
       - run: mix compile --warnings-as-errors
       - run: mix test --cover --export-coverage ci --trace --warnings-as-errors
       - run: mix test.coverage
@@ -61,6 +61,8 @@ jobs:
   dialyzer:
     name: Dialyzer
     runs-on: ubuntu-latest
+    env:
+      MIX_ENV: dev
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -71,5 +73,5 @@ jobs:
         with:
           path: _build/${{env.MIX_ENV}}/dialyxir_*
           key: ${{runner.os}}-mix-dialyxir
-      - run: mix deps.get
+      - run: mix deps.get --only
       - run: mix dialyzer --list-unused-filters

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,11 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
+      # Test each supported Elixir minor version. For each Elixir version,
+      # use the latest OTP and latest of each supported OS
+      # https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-20.04, windows-2022]
         elixir: ['1.12.3', '1.13.4']
         include:
           - otp: '24'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
           test -f doc/index.html && echo "doc/index.html exists."
 
 
+  # https://github.com/jeremyjh/dialyxir#github-actions
   dialyzer:
     name: Dialyzer
     runs-on: ubuntu-latest
@@ -65,13 +66,19 @@ jobs:
       MIX_ENV: dev
     steps:
       - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
+      - id: beam
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.13.4'
           otp-version: '24'
-      - uses: actions/cache@v2
+      - id: plt_cache
+        uses: actions/cache@v2
         with:
           path: _build/${{env.MIX_ENV}}/dialyxir_*
-          key: ${{runner.os}}-mix-dialyxir
+          key: plt-${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}
+          restore-keys: plt-${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}
       - run: mix deps.get --only
+      - name: Create PLTs
+        if: steps.plt_cache.outputs.cache-hit != 'true'
+        run: mix dialyzer --plt
       - run: mix dialyzer --list-unused-filters


### PR DESCRIPTION
* Fix test job matrix dimensions
* Update to `windows-2022`
* Use consistent deps.git in Workflow CI
* Fix Dialyzer PLT cache
* Add Dependabot update for mix

---

I misunderstood how `include` interacts with matrix fields.
https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs

I moved `elixir` to its own field, keeping `otp` as an `include`.
In the future, as we add Elixir versions, we can override/change `otp` values based on the Elixir version, e.g.

```yaml
matrix:
  os: [ubuntu-20.04, windows-2019]
  elixir: ['1.12.3', '1.13.4']
  include:
    - otp: '24'
    - elixir '1.12.3'
      otp: '22'
```

However, as I understand it, `include` does not allow for multiple matches. We'd need to radically change the matrix if we wanted to to also test multiple OTP versions per Elixir versions.

---

I was not restoring the PLT cache on run. Updated based on https://github.com/jeremyjh/dialyxir#github-actions