### PR TITLE
Support Elixir 1.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+env:
+  DEFAULT_ELIXIR_VERSION: '1.14'
+  DEFAULT_OTP_VERSION: '25'
+
 jobs:
   lint:
     name: Lint
@@ -14,8 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.13.4'
-          otp-version: '24'
+          elixir-version: ${{ env.DEFAULT_ELIXIR_VERSION }}
+          otp-version: ${{ env.DEFAULT_OTP_VERSION }}
       - run: mix deps.get --only
       - run: mix format --check-formatted
       - run: mix deps.unlock --check-unused
@@ -28,11 +32,14 @@ jobs:
       # Test each supported Elixir minor version. For each Elixir version,
       # use the latest OTP and latest of each supported OS
       # https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp
+      # https://hexdocs.pm/elixir/1.14.0/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
       matrix:
-        os: [ubuntu-20.04, windows-2022]
-        elixir: ['1.12.3', '1.13.4']
+        os: [ubuntu-22.04, windows-2022]
+        elixir: ['1.12', '1.13', '1.14']
         include:
+          - otp: '25'
           - otp: '24'
+            elixir: '1.12'
     env:
       MIX_ENV: test
     steps:
@@ -69,8 +76,8 @@ jobs:
       - id: beam
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.13.4'
-          otp-version: '24'
+          elixir-version: ${{ env.DEFAULT_ELIXIR_VERSION }}
+          otp-version: ${{ env.DEFAULT_OTP_VERSION }}
       - id: plt_cache
         uses: actions/cache@v2
         with:

--- a/lib/riot/lor/deck_code.ex
+++ b/lib/riot/lor/deck_code.ex
@@ -3,7 +3,7 @@ defmodule Riot.LoR.DeckCode do
   Functions to encode/decode a LoR deck code.
   """
 
-  use Bitwise, only_operators: true
+  import Bitwise
 
   alias Riot.LoR.Card
   alias Riot.LoR.Deck

--- a/lib/riot/util/varint/leb128.ex
+++ b/lib/riot/util/varint/leb128.ex
@@ -17,7 +17,7 @@ defmodule Riot.Util.Varint.LEB128 do
 
   alias Riot.Util.Varint
 
-  use Bitwise, only_operators: true
+  import Bitwise
 
   import Riot.Util.Varint, only: [has_octet: 1, is_pos_integer: 1]
 

--- a/lib/riot/util/varint/vlq.ex
+++ b/lib/riot/util/varint/vlq.ex
@@ -6,7 +6,7 @@ defmodule Riot.Util.Varint.VLQ do
 
   alias Riot.Util.Varint
 
-  use Bitwise, only_operators: true
+  import Bitwise
 
   import Riot.Util.Varint, only: [has_octet: 1, is_pos_integer: 1]
 

--- a/test/riot/util/varint/leb128_test.exs
+++ b/test/riot/util/varint/leb128_test.exs
@@ -2,7 +2,6 @@ defmodule Riot.Util.Varint.LEB128Test do
   alias Riot.Util.Varint
   alias Riot.Util.Varint.LEB128
 
-  use Bitwise, only_operators: true
   use ExUnit.Case
   use ExUnitProperties
 

--- a/test/riot/util/varint/vlq_test.exs
+++ b/test/riot/util/varint/vlq_test.exs
@@ -2,9 +2,10 @@ defmodule Riot.Util.Varint.VLQTest do
   alias Riot.Util.Varint
   alias Riot.Util.Varint.VLQ
 
-  use Bitwise, only_operators: true
   use ExUnit.Case
   use ExUnitProperties
+
+  import Bitwise
 
   doctest VLQ
 


### PR DESCRIPTION
Code:
* Import `Bitwise` (instead of `use`) --     https://github.com/elixir-lang/elixir/blob/v1.14/CHANGELOG.md#4-hard-deprecations

Workflow:
 * Set default Elixir/OTP values
          * Elixir: 1.14
          * OTP: 25
  * Update hard-coded latest versions to `env` values
  * Add link to Elixir/OTP compatibility page
  * Remove patch versions to use latest
  * Update matrix includes for specific OTP values
  * Bump Ubuntu to 22.04